### PR TITLE
Overwrite last command

### DIFF
--- a/collections_undo/_command.py
+++ b/collections_undo/_command.py
@@ -111,7 +111,7 @@ class Command(_CommandBase):
             return self.func.format_reverse_call(*self.args, **self.kwargs)
         return self.func.format_forward_call(*self.args, **self.kwargs)
 
-    def automerge(self, cmd: Command) -> Self:
+    def automerge_with(self, cmd: Command) -> Self:
         """Automatically merge the command with the given command."""
         rule = cmd.func._automerge_rule
         if rule is None:

--- a/collections_undo/_command.py
+++ b/collections_undo/_command.py
@@ -119,7 +119,7 @@ class Command(_CommandBase):
         if self.func is not cmd.func:
             raise ValueError(f"Cannot merge different functions.")
         _args, _kwargs = rule(self.bind_args().arguments, cmd.bind_args().arguments)
-        return self.__class__(self.func, _args, _kwargs)  # TODO: size?
+        return self.__class__(self.func, _args, _kwargs)
 
 
 class CommandGroup(_CommandBase):

--- a/collections_undo/_const.py
+++ b/collections_undo/_const.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable, Any, Dict
+from typing import Callable, Any, Tuple, Dict
 
 
 class _Empty:
@@ -14,3 +14,5 @@ empty = _Empty()
 
 
 FormatterType = Callable[[Callable, tuple, Dict[str, Any]], str]
+Args = Tuple[Tuple[Any], Dict[str, Any]]
+AutoMergeRuleType = Callable[[Dict[str, Any], Dict[str, Any]], Args]

--- a/collections_undo/_reversible.py
+++ b/collections_undo/_reversible.py
@@ -152,16 +152,23 @@ class ReversibleFunction(Generic[_P, _R, _RR]):
             return self
         _id = id(obj)
         if (out := self._instances.get(_id, None)) is None:
+            # get inverse function
             if self._func_rv is None:
                 inv_func = None
             else:
                 inv_func = self._func_rv.__get__(obj, objtype)
+
+            # register instance
             self._instances[_id] = out = type(self)(
                 func=self._func_fw.__get__(obj, objtype),
                 mgr=self._mgr.__get__(obj, objtype),
                 inverse_func=inv_func,
             )
+
+            # copy name
             out.__name__ = self.__name__
+
+            # get formatters
             if self._formatter_fw is self._formatter_rv:
                 out._formatter_fw = out._formatter_rv = _as_method(
                     self._formatter_fw, obj
@@ -169,8 +176,15 @@ class ReversibleFunction(Generic[_P, _R, _RR]):
             else:
                 out._formatter_fw = _as_method(self._formatter_fw, obj)
                 out._formatter_rv = _as_method(self._formatter_rv, obj)
+
+            # copy argument mapping
             out._map_args = self._map_args
-            out._automerge_rule = self._automerge_rule
+
+            # get automerge rule
+            if self._automerge_rule is not None:
+                out._automerge_rule = _as_method(self._automerge_rule, obj)
+            else:
+                out._automerge_rule = None
         return out
 
     @classmethod
@@ -208,7 +222,7 @@ class ReversibleFunction(Generic[_P, _R, _RR]):
             mgr=self._mgr,
         )
 
-    def set_automerge_rule(self, rule: AutoMergeRuleType):
+    def automerge_rule(self, rule: AutoMergeRuleType):
         self._automerge_rule = rule
         return rule
 

--- a/collections_undo/_stack.py
+++ b/collections_undo/_stack.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 from contextlib import contextmanager
-from enum import Enum
 from typing import (
     Any,
     Callable,
-    Iterator,
     Literal,
-    MutableSequence,
-    NamedTuple,
     TYPE_CHECKING,
     TypeVar,
     overload,
@@ -18,78 +14,15 @@ from ._reversible import ReversibleFunction
 from ._undoable import UndoableInterface, UndoableProperty
 from ._command import Command, _CommandBase
 from ._const import empty
+from ._stack_utils import LengthPair, CallbackList, CallType
 
 if TYPE_CHECKING:
     from typing_extensions import Self, ParamSpec
 
     _P = ParamSpec("_P")
     _R = TypeVar("_R")
-    _RR = TypeVar("_RR")
 
 _F = TypeVar("_F", bound=Callable)
-
-
-class CallbackList(MutableSequence[_F]):
-    """
-    A list of callbacks of UndoManager updates.
-
-    Callbacks are useful for such as logging.
-    """
-
-    def __init__(self) -> None:
-        self._list = []
-
-    def insert(self, index: int, callback: _F, /):
-        self._check_callable(callback)
-        self._list.insert(index, callback)
-
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}({self._list!r})"
-
-    def __len__(self) -> int:
-        return len(self._list)
-
-    def __iter__(self) -> Iterator[_F]:
-        return iter(self._list)
-
-    def __getitem__(self, key):
-        return self._list[key]
-
-    def __setitem__(self, key, callback):
-        self._check_callable(callback)
-        self._list[key] = callback
-
-    def __delitem__(self, key):
-        del self._list[key]
-
-    def evoke(self, *args, **kwargs) -> None:
-        """Evoce all callbacks."""
-        for callback in self._list:
-            callback(*args, **kwargs)
-        return None
-
-    @staticmethod
-    def _check_callable(obj):
-        if not callable(obj):
-            raise TypeError("Can only insert callable object to the callback list.")
-
-
-class CallType(Enum):
-    call = "call"
-    undo = "undo"
-    redo = "redo"
-
-    def __eq__(self, other):
-        if isinstance(other, str):
-            return self.value == other
-        return super().__eq__(other)
-
-
-class LengthPair(NamedTuple):
-    """Pair of stack size."""
-
-    undo: int
-    redo: int
 
 
 def always_zero(*args, **kwargs) -> float:

--- a/collections_undo/_stack.py
+++ b/collections_undo/_stack.py
@@ -186,7 +186,8 @@ class UndoManager:
             last_cmd = self._state.stack_undo[-1]
             if isinstance(last_cmd, Command):
                 new_cmd = last_cmd.automerge_with(cmd)
-                self._state.stack_undo.pop(-1)
+                popped_cmd = self._state.stack_undo.pop(-1)
+                self._state.stack_undo_size -= popped_cmd.size
             else:
                 new_cmd = cmd
             self._state.stack_undo.append(new_cmd)

--- a/collections_undo/_stack.py
+++ b/collections_undo/_stack.py
@@ -185,7 +185,7 @@ class UndoManager:
         if self._state.is_automerging and len(self._state.stack_undo) > 0:
             last_cmd = self._state.stack_undo[-1]
             if isinstance(last_cmd, Command):
-                new_cmd = last_cmd.automerge(cmd)
+                new_cmd = last_cmd.automerge_with(cmd)
                 self._state.stack_undo.pop(-1)
             else:
                 new_cmd = cmd
@@ -334,6 +334,11 @@ class UndoManager:
                 self.called.evoke(self._state.stack_undo[-1], CallType.call)
         return None
 
+    def set_merge(self, enabled: bool) -> None:
+        """Enable/disable merging."""
+        self._state.is_merging = bool(enabled)
+        return None
+
     @contextmanager
     def blocked(self):
         """Block new command from being appended to the stack."""
@@ -363,6 +368,11 @@ class UndoManager:
             yield None
         finally:
             self._state.is_automerging = was_automerging
+        return None
+
+    def set_automerge(self, enabled: bool):
+        """Enable/disable auto-merging."""
+        self._state.is_automerging = bool(enabled)
         return None
 
 

--- a/collections_undo/_stack_utils.py
+++ b/collections_undo/_stack_utils.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+from enum import Enum
+from typing import (
+    Callable,
+    Iterator,
+    MutableSequence,
+    NamedTuple,
+    TypeVar,
+)
+
+_F = TypeVar("_F", bound=Callable)
+
+
+class CallbackList(MutableSequence[_F]):
+    """
+    A list of callbacks of UndoManager updates.
+
+    Callbacks are useful for such as logging.
+    """
+
+    def __init__(self) -> None:
+        self._list = []
+
+    def insert(self, index: int, callback: _F, /):
+        self._check_callable(callback)
+        self._list.insert(index, callback)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self._list!r})"
+
+    def __len__(self) -> int:
+        return len(self._list)
+
+    def __iter__(self) -> Iterator[_F]:
+        return iter(self._list)
+
+    def __getitem__(self, key):
+        return self._list[key]
+
+    def __setitem__(self, key, callback):
+        self._check_callable(callback)
+        self._list[key] = callback
+
+    def __delitem__(self, key):
+        del self._list[key]
+
+    def evoke(self, *args, **kwargs) -> None:
+        """Evoce all callbacks."""
+        for callback in self._list:
+            callback(*args, **kwargs)
+        return None
+
+    @staticmethod
+    def _check_callable(obj):
+        if not callable(obj):
+            raise TypeError("Can only insert callable object to the callback list.")
+
+
+class CallType(Enum):
+    call = "call"
+    undo = "undo"
+    redo = "redo"
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.value == other
+        return super().__eq__(other)
+
+
+class LengthPair(NamedTuple):
+    """Pair of stack size."""
+
+    undo: int
+    redo: int

--- a/collections_undo/_undoable.py
+++ b/collections_undo/_undoable.py
@@ -220,7 +220,7 @@ class UndoableProperty(property):
             old_val = self.fget(obj)
             setattr.__get__(obj)(val, old_val)
 
-        setattr._automerge_rule = self._automerge_rule
+        setattr._automerge_rule = self._setter_automerge_rule
 
         # update names and the formatter
 
@@ -267,7 +267,7 @@ class UndoableProperty(property):
         return args, kwargs
 
     @staticmethod
-    def _automerge_rule(obj, args0: dict[str, Any], args1: dict[str, Any]):
+    def _setter_automerge_rule(obj, args0: dict[str, Any], args1: dict[str, Any]):
         # obj, val, old_val
         old = args0["old_val"]
         new = args1["val"]

--- a/collections_undo/_undoable.py
+++ b/collections_undo/_undoable.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 from functools import partial, wraps
 from typing import Any, Callable, TYPE_CHECKING, Generic, Literal, TypeVar
-from ._reversible import ReversibleFunction
-from ._const import empty, FormatterType
+from collections_undo._reversible import ReversibleFunction
+from collections_undo._const import empty, FormatterType, Args
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
-    from ._stack import UndoManager
+    from collections_undo._stack import UndoManager
 
     _P = ParamSpec("_P")
-    ArgsType = tuple[tuple, dict[str, Any]]
-    _Args = TypeVar("_Args", bound=ArgsType)
+    _Args = TypeVar("_Args", bound=Args)
 else:
     _P = TypeVar("_P")
     _Args = TypeVar("_Args")
@@ -134,13 +133,17 @@ class UndoableInterface(Generic[_P, _R, _Args]):
         return f"{type(self).__name__}<{self._freceive!r}>"
 
     def _create_function(self) -> ReversibleFunction:
-        def fw(new: ArgsType, old: ArgsType):
+        """Create a reversible function from the interface."""
+
+        # forward function
+        def fw(new: Args, old: Args):
             args, kwargs = new
             return self._freceive(*args, **kwargs)
 
         fw.__name__ = self.__name__
 
-        def rv(new: ArgsType, old: ArgsType):
+        # reverse function
+        def rv(new: Args, old: Args):
             if old is None:
                 return empty
             args, kwargs = old


### PR DESCRIPTION
Functions such as `__setitem__` should be overwritten if called in a row. Adding supports for this kind of options.