### PR TITLE
Use context manager to define an undoable function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Python package index download statistics](https://img.shields.io/pypi/dm/collections-undo.svg)](https://pypistats.org/packages/collections-undo)
+[![PyPI version](https://badge.fury.io/py/collections-undo.svg)](https://badge.fury.io/py/collections-undo)
+
 # collections-undo
 
 General undo/redo implementation in Python.
@@ -5,7 +8,7 @@ General undo/redo implementation in Python.
 
 ### Installation
 
-```
+```shell
 pip install -U collections-undo
 ```
 

--- a/collections_undo/_stack.py
+++ b/collections_undo/_stack.py
@@ -11,7 +11,7 @@ from typing import (
 from functools import wraps
 
 from ._reversible import ReversibleFunction
-from ._undoable import UndoableInterface, UndoableProperty
+from ._undoable import UndoableInterface, UndoableProperty, UndoableGenerator
 from ._command import Command, _CommandBase
 from ._const import empty
 from ._stack_utils import LengthPair, CallbackList, CallType
@@ -207,10 +207,15 @@ class UndoManager:
             self._state.stack_undo_size -= cmd.size
         return None
 
-    def _append_command(self, cmd, *args, **kwargs):
-        cmd = Command(func=cmd, args=args, kwargs=kwargs)
-        cmd.size = self._state.measure(*args, **kwargs)
-        return self.append(cmd)
+    def _append_command(
+        self,
+        fn: ReversibleFunction[_P, Any, Any],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> None:
+        _cmd = Command(func=fn, args=args, kwargs=kwargs)
+        _cmd.size = self._state.measure(*args, **kwargs)
+        return self.append(_cmd)
 
     def clear(self) -> None:
         """Clear the stack."""
@@ -276,11 +281,7 @@ class UndoManager:
     ) -> Callable[[Callable[_P, _R]], UndoableInterface[_P, _R, Any]]:
         ...
 
-    def interface(
-        self,
-        func: Callable | None = None,
-        name: str | None = None,
-    ) -> UndoableInterface:
+    def interface(self, func=None, name=None) -> UndoableInterface:
         """Decorator for undoable setter function construction."""
 
         def _wrapper(f):
@@ -288,6 +289,19 @@ class UndoManager:
             if name is not None:
                 itf.__name__ = name
             return itf
+
+        return _wrapper if func is None else _wrapper(func)
+
+    def contexted(
+        self,
+        func=None,
+        name=None,
+    ):
+        def _wrapper(f):
+            gen = UndoableGenerator(f, mgr=self)
+            if name is not None:
+                gen.__name__ = name
+            return gen
 
         return _wrapper if func is None else _wrapper(func)
 

--- a/collections_undo/_stack.py
+++ b/collections_undo/_stack.py
@@ -270,7 +270,7 @@ class UndoManager:
     @overload
     def interface(
         self, func: Callable[_P, _R], name: str | None = None
-    ) -> UndoableInterface[_P, _R, Any]:
+    ) -> UndoableInterface[_P, _R, _R]:
         ...
 
     @overload
@@ -278,7 +278,7 @@ class UndoManager:
         self,
         func: Literal[None],
         name: str | None = None,
-    ) -> Callable[[Callable[_P, _R]], UndoableInterface[_P, _R, Any]]:
+    ) -> Callable[[Callable[_P, _R]], UndoableInterface[_P, _R, _R]]:
         ...
 
     def interface(self, func=None, name=None) -> UndoableInterface:
@@ -292,11 +292,21 @@ class UndoManager:
 
         return _wrapper if func is None else _wrapper(func)
 
+    @overload
     def contexted(
-        self,
-        func=None,
-        name=None,
-    ):
+        self, func: Callable[_P, _R], name: str | None = None
+    ) -> UndoableGenerator[_P, _R, _R]:
+        ...
+
+    @overload
+    def contexted(
+        self, func: Literal[None], name: str | None = None
+    ) -> Callable[[Callable[_P, _R]], UndoableGenerator[_P, _R, _R]]:
+        ...
+
+    def contexted(self, func=None, name=None):
+        """Decorator for undoable generator construction."""
+
         def _wrapper(f):
             gen = UndoableGenerator(f, mgr=self)
             if name is not None:

--- a/rst/index.rst
+++ b/rst/index.rst
@@ -30,7 +30,7 @@ ones. The history of function call is recorded in the ``UndoManager``.
 
    mgr = UndoManager()
 
-Here are three most practically useful decorators listed up below.
+Here are some most practically useful decorators listed up below.
 
 .. toctree::
    :maxdepth: 1
@@ -38,6 +38,7 @@ Here are three most practically useful decorators listed up below.
    ./main/reversible
    ./main/interface
    ./main/property
+   ./main/generator
 
 You can merge commands into a single undoable command.
 

--- a/rst/main/generator.rst
+++ b/rst/main/generator.rst
@@ -1,0 +1,28 @@
+===================
+Generator Framework
+===================
+
+Python generator is a versatile tool. In :mod:`collections-undo` you can also use
+generator functions to define undoable functions, in a similar way as you define
+context managers with :meth:`contextlib.contextmanager`.
+
+Following example shows how to define an undoable setter.
+
+.. code-block:: python
+
+    from collections_undo import UndoManager
+
+    class A:
+        mgr = UndoManager()
+
+        def __init__(self):
+        self._state = 0
+
+        @mgr.contexted
+        def set_state(self, x):
+            # do-statement before yield
+            old = x
+            self._state = x
+            yield
+            # undo-statement after yield
+            self._state = old

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -381,3 +381,32 @@ def test_reduce_property():
     assert a.x == 0
     a.mgr.redo()
     assert a.x == 15
+
+def test_generator():
+    class A:
+        mgr = UndoManager()
+
+        def __init__(self) -> None:
+            self._state = 0
+
+        @mgr.contexted
+        def set_state(self, state: int):
+            old = self._state
+            self._state = state
+            yield
+            self._state = old
+
+    a = A()
+    assert a._state == 0
+    a.set_state(-1)
+    assert a._state == -1
+    a.set_state(1)
+    assert a._state == 1
+    a.mgr.undo()
+    assert a._state == -1
+    a.mgr.undo()
+    assert a._state == 0
+    a.mgr.redo()
+    assert a._state == -1
+    a.mgr.redo()
+    assert a._state == 1


### PR DESCRIPTION
Undo/redo can be defined in a single generator function. It is hard to automatically define a reduce rule but is very powerful way to make a just-working undoable function.

```python
def func(self, a):
    old = self._value
    self._value = a
    yield a  # <- real return value
    self._value = old  # <- executed in redo session
```